### PR TITLE
feat: Setup remote API

### DIFF
--- a/src/apiCalls.js
+++ b/src/apiCalls.js
@@ -1,7 +1,7 @@
 import handleError from "./scripts";
 
 const fetchApi = (url) => {
-  return fetch(`http://localhost:3001/api/v1/${url}`)
+  return fetch(`https://whats-cookin-api.vercel.app/api/v1/${url}`)
     .then((response) => {
       if (response.ok) {
         return response.json();
@@ -21,7 +21,7 @@ const fetchAllData = () => {
 }
 
 const updateFavorite = (userID, recipeID, method) => {
-  return fetch('http://localhost:3001/api/v1/usersRecipes', {
+  return fetch('https://whats-cookin-api.vercel.app/api/v1/', {
     method: method,
     body: JSON.stringify({userID: userID, recipeID: recipeID}), 
     headers: {


### PR DESCRIPTION
This branch replaces the fetch request URLs with the remote API URL hosted on Vercel.

[Vercel API](https://whats-cookin-api.vercel.app/api/v1/)
Root: `https://whats-cookin-api.vercel.app/api/v1/`